### PR TITLE
Specify an older, more vulnerable Debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM debian:10
+FROM debian:8


### PR DESCRIPTION
This pull request is intended to fail, because the Snyk GitHub Action is set to fail on finding high-severity vulnerabilities and the PR introduces an old version of the base image. You can see the vulnerabilities discovered in the Action output.

![Screenshot 2020-09-11 at 08 33 31](https://user-images.githubusercontent.com/2029/92884168-7f8c3700-f409-11ea-97a6-611134ad0544.png)
